### PR TITLE
Extension allowing the use of a different certstream server

### DIFF
--- a/src/example/ExampleClientAlternativeServer.java
+++ b/src/example/ExampleClientAlternativeServer.java
@@ -1,0 +1,18 @@
+package example;
+
+import com.google.gson.Gson;
+import io.calidog.certstream.CertStream;
+
+/**
+ * Demo Client that prints out a message of a certstream-server with a given URI
+ * The server address of the CaliDog Server is entered here for demo purposes
+ */
+public class ExampleClientAlternativeServer {
+
+    public static void main (String[] args){
+
+        CertStream.onMessageAlternativeServer(msg -> System.out.println(new Gson().toJson(msg)), "wss://certstream.calidog.io");
+
+    }
+
+}

--- a/src/io/calidog/certstream/BoringParts.java
+++ b/src/io/calidog/certstream/BoringParts.java
@@ -43,6 +43,16 @@ public class BoringParts implements
         webSocketClient = webSocketClientSupplier.get();
     }
 
+    /**
+     * Constructor for the connection to an alternative server
+     * @param serverURI String representation of the alternative server's address
+     */
+    public BoringParts(CertStreamStringMessageHandler messageHandler, long sleepBeforeReconnect, String serverURI){
+        this.sleepBeforeReconnect = sleepBeforeReconnect;
+        this.webSocketClientSupplier = () -> defaultImplFactory.make(messageHandler, serverURI);
+        this.webSocketClient = webSocketClientSupplier.get();
+    }
+
     //todo reconnection logic
     @Override
     public void onClose(int i, String s, boolean b) {

--- a/src/io/calidog/certstream/CertStream.java
+++ b/src/io/calidog/certstream/CertStream.java
@@ -26,18 +26,24 @@ public class CertStream{
         {
             BoringParts theBoringParts = new BoringParts(handler::accept);
 
-            while (theBoringParts.isNotClosed())
-            {
-                Thread.yield();
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {}
+            runThread(theBoringParts);
 
-                if (Thread.interrupted())
-                {
-                    break;
-                }
-            }
+        }).start();
+    }
+
+    /**
+     * @param handler A {@link Consumer<String>} that we'll
+     *                run in a Thread that stays alive as long
+     *                as the WebSocket stays open
+     * @param serverURI Address of the server to which a  WebSocket
+     *                  connection is established
+     */
+    public static void onMessageStringAlternativeServer(Consumer<String> handler, String serverURI){
+        new Thread(() -> {
+            BoringParts theBoringParts = new BoringParts(handler::accept, 0 , serverURI);
+
+            runThread(theBoringParts);
+
         }).start();
     }
 
@@ -79,5 +85,61 @@ public class CertStream{
 
             handler.onMessage(fullMsg);
         });
+    }
+
+    /**
+     * @param handler A {@link Consumer<CertStreamMessage>} that we'll
+     *                run in a Thread that stays alive as long
+     *                as the WebSocket stays open
+     * @param serverURI Address of the server to which a  WebSocket
+     *                  connection is established
+     */
+    public static void onMessageAlternativeServer (CertStreamMessageHandler handler, String serverURI){
+        onMessageStringAlternativeServer(string -> {
+            CertStreamMessagePOJO msg;
+
+            try {
+                msg = new Gson().fromJson(string, CertStreamMessagePOJO.class);
+
+                if (msg.messageType.equalsIgnoreCase("heartbeat")) {
+                    return;
+                }
+            } catch (JsonSyntaxException e) {
+                System.out.println(e.getMessage());
+                logger.warn("onMessageAlternativeServer had an exception parsing some json", e);
+                return;
+            }
+
+            CertStreamMessage fullMsg;
+
+            try {
+                fullMsg = CertStreamMessage.fromPOJO(msg);
+            } catch (CertificateException e){
+                logger.warn("Encountered a CertificateException", e);
+                return;
+            }
+
+            handler.onMessage(fullMsg);
+        }, serverURI);
+    }
+
+    /**
+     * Runs thread until WebSocket is closed
+     * @param theBoringParts Websocket connection that is checked
+     *                       to see if it has been closed
+     */
+    public static void runThread(BoringParts theBoringParts) {
+        while (theBoringParts.isNotClosed())
+        {
+            Thread.yield();
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {}
+
+            if (Thread.interrupted())
+            {
+                break;
+            }
+        }
     }
 }

--- a/src/io/calidog/certstream/CertStreamClientImpl.java
+++ b/src/io/calidog/certstream/CertStreamClientImpl.java
@@ -27,6 +27,16 @@ public class CertStreamClientImpl extends WebSocketClient{
         this.connect();
     }
 
+    /**
+     * Constructor for alternative Server
+     * @param serverURI String representation of server-address
+     */
+    public CertStreamClientImpl(CertStreamClient client, String serverURI) throws URISyntaxException {
+        super(new URI(serverURI));
+        this.client = client;
+        this.connect();
+    }
+
     public void onOpen(ServerHandshake serverHandshake) {
         client.onOpen(serverHandshake);
     }

--- a/src/io/calidog/certstream/CertStreamClientImplFactory.java
+++ b/src/io/calidog/certstream/CertStreamClientImplFactory.java
@@ -2,6 +2,8 @@ package io.calidog.certstream;
 
 import org.java_websocket.handshake.ServerHandshake;
 
+import java.net.URISyntaxException;
+
 /**
  * A bundler around a functional interface. This is the little bit of magic
  * that lets you just pass in a {@link java.util.function.Consumer} and have
@@ -30,12 +32,39 @@ public class CertStreamClientImplFactory {
 
     /**
      * @param messageHandler The handler for onMessage
-     * @return a complete CertStreamClientImpl made out of a function
-     * and the handlers this Object was initialized with
+     * @return CertStreamClientImpl connected to the
+     * default sever ("wss://certstream.calidog.io")
      */
     public CertStreamClientImpl make(CertStreamStringMessageHandler messageHandler)
     {
-        return new CertStreamClientImpl(new CertStreamClient() {
+        return new CertStreamClientImpl(createClient(messageHandler));
+    }
+
+    /**
+     *
+     * @param messageHandler The handler for onMessage
+     * @param serverURI String representation of the address of the alternative server
+     * @return CertStreamClientImpl connected to an
+     * alternative Certstream-Server
+     */
+    public CertStreamClientImpl make(CertStreamStringMessageHandler messageHandler, String serverURI){
+        CertStreamClientImpl certStreamClient = null;
+        try {
+            certStreamClient = new CertStreamClientImpl(createClient(messageHandler), serverURI);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+        return certStreamClient;
+    }
+
+    /**
+     *
+     * @param messageHandler The handler for onMessage
+     * @return a complete CertStreamClientImpl made out of a function
+     * and the handlers this Object was initialized with
+     */
+    public CertStreamClient createClient(CertStreamStringMessageHandler messageHandler){
+        return new CertStreamClient() {
             @Override
             public void onOpen(ServerHandshake serverHandshake) {
                 openHandler.onOpen(serverHandshake);
@@ -55,7 +84,7 @@ public class CertStreamClientImplFactory {
             public void onError(Exception e) {
                 errorHandler.onError(e);
             }
-        });
+        };
     }
 
 


### PR DESCRIPTION
Hi there,

I have added a few methods to allow users to use this library with another / their own certstream server instead of always having to access the default server "certstream.calidog.io".

Thank you for providing this project! Looking forward to your response. 