### PR TITLE
Fix Deserialization error when "extensions" contains "extra" field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #Intellij's dirty laundry
 .idea/*
+*.iml
 
 #maven build artifcts
 target/*

--- a/src/io/calidog/certstream/CertStream.java
+++ b/src/io/calidog/certstream/CertStream.java
@@ -1,6 +1,7 @@
 package io.calidog.certstream;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,13 +61,13 @@ public class CertStream{
             CertStreamMessagePOJO msg;
             try
             {
-                msg = new Gson().fromJson(string, CertStreamMessagePOJO.class);
+                msg = certStreamGson.fromJson(string, CertStreamMessagePOJO.class);
 
                 if (msg.messageType.equalsIgnoreCase("heartbeat"))
                 {
                     return;
                 }
-            }catch (JsonSyntaxException e)
+            } catch (JsonSyntaxException e)
             {
                 System.out.println(e.getMessage());
                 logger.warn("onMessage had an exception parsing some json", e);
@@ -87,6 +88,15 @@ public class CertStream{
         });
     }
 
+    private static Gson certStreamGson =
+            new GsonBuilder()
+                    .registerTypeAdapter
+                    (
+                        CertStreamCertificatePOJO.class,
+                        new CertStreamCertificatePOJODeserializer()
+                    )
+                    .create();
+
     /**
      * @param handler A {@link Consumer<CertStreamMessage>} that we'll
      *                run in a Thread that stays alive as long
@@ -99,7 +109,7 @@ public class CertStream{
             CertStreamMessagePOJO msg;
 
             try {
-                msg = new Gson().fromJson(string, CertStreamMessagePOJO.class);
+                msg = certStreamGson.fromJson(string, CertStreamMessagePOJO.class);
 
                 if (msg.messageType.equalsIgnoreCase("heartbeat")) {
                     return;

--- a/src/io/calidog/certstream/CertStreamCertificate.java
+++ b/src/io/calidog/certstream/CertStreamCertificate.java
@@ -16,7 +16,7 @@ import java.util.*;
  */
 public class CertStreamCertificate extends X509Certificate {
     private HashMap<String, String> subject;
-    private HashMap<String, String> extensions;
+    private HashMap<String, String[]> extensions;
 
     private double notBefore;
     private double notAfter;
@@ -257,7 +257,7 @@ public class CertStreamCertificate extends X509Certificate {
      * passed-in oid String. The oid string is represented
      * by whatever CertStream passes us.
      */
-    public String getStringExtensionValue(String key)
+    public String[] getStringExtensionValue(String key)
     {
         return extensions.get(key);
     }

--- a/src/io/calidog/certstream/CertStreamCertificate.java
+++ b/src/io/calidog/certstream/CertStreamCertificate.java
@@ -1,11 +1,8 @@
 package io.calidog.certstream;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import javax.security.auth.x500.X500Principal;
 import java.math.BigInteger;
 import java.security.*;
-import java.security.cert.Certificate;
 import java.security.cert.*;
 import java.time.Instant;
 import java.util.*;
@@ -77,25 +74,25 @@ public class CertStreamCertificate extends X509Certificate {
     /**Not implemented*/
     @Override
     public int getVersion() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public BigInteger getSerialNumber() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public Principal getIssuerDN() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public X500Principal getIssuerX500Principal() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
@@ -122,66 +119,66 @@ public class CertStreamCertificate extends X509Certificate {
     /**Not implemented*/
     @Override
     public byte[] getTBSCertificate() throws CertificateEncodingException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
     /**Not implemented*/
     @Override
     public byte[] getSignature() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public String getSigAlgName() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public String getSigAlgOID() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public byte[] getSigAlgParams() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public boolean[] getIssuerUniqueID() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public boolean[] getSubjectUniqueID() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public boolean[] getKeyUsage() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public List<String> getExtendedKeyUsage() throws CertificateParsingException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public int getBasicConstraints() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public Collection<List<?>> getSubjectAlternativeNames() throws CertificateParsingException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -206,49 +203,49 @@ public class CertStreamCertificate extends X509Certificate {
     /**Not implemented*/
     @Override
     public void verify(PublicKey publicKey) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public void verify(PublicKey publicKey, String s) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public String toString() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public PublicKey getPublicKey() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public boolean hasUnsupportedCriticalExtension() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public Set<String> getCriticalExtensionOIDs() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public Set<String> getNonCriticalExtensionOIDs() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**Not implemented*/
     @Override
     public byte[] getExtensionValue(String s) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/io/calidog/certstream/CertStreamCertificatePOJO.java
+++ b/src/io/calidog/certstream/CertStreamCertificatePOJO.java
@@ -12,7 +12,9 @@ public class CertStreamCertificatePOJO {
 
     HashMap<String, String> subject;
 
-    HashMap<String, String> extensions;
+    // values can be either strings or lists of strings, so we use a a custom deserializer
+    // that converts strings into singleton arrays
+    HashMap<String, String[]> extensions;
 
     @SerializedName("not_before")
     double notBefore;

--- a/src/io/calidog/certstream/CertStreamCertificatePOJODeserializer.java
+++ b/src/io/calidog/certstream/CertStreamCertificatePOJODeserializer.java
@@ -4,6 +4,7 @@ import com.google.gson.*;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.Map;
 
 public class CertStreamCertificatePOJODeserializer implements JsonDeserializer<CertStreamCertificatePOJO> {
 
@@ -13,50 +14,47 @@ public class CertStreamCertificatePOJODeserializer implements JsonDeserializer<C
             Type type,
             JsonDeserializationContext jsonDeserializationContext
     ) throws JsonParseException {
+
         JsonObject jsonObj = jsonElement.getAsJsonObject();
+        JsonObject jsonExtensions = new JsonObject();
 
-        JsonObject jsonExtensions;
-
-        HashMap<String, String[]> extensionMap = null;
-
+        // remove extensions from json object
         if (jsonObj.has("extensions"))
         {
             jsonExtensions = jsonObj.remove("extensions").getAsJsonObject();
-
-            final HashMap<String, String[]> finalExtensionMap = new HashMap<>(jsonExtensions.size());
-
-            jsonExtensions
-                    .entrySet()
-                    .forEach
-                    (
-                            (java.util.Map.Entry<String, JsonElement> entry) ->
-                            {
-                                String key = entry.getKey();
-                                JsonElement value = entry.getValue();
-                                String[] extensionValueList;
-                                try {
-                                    extensionValueList = new String[] { value.getAsString() };
-                                } catch (IllegalStateException | UnsupportedOperationException e) {
-                                    JsonArray extensionJsonArray = value.getAsJsonArray();
-                                    extensionValueList = new String[extensionJsonArray.size()];
-
-                                    for (int i = 0; i < extensionJsonArray.size(); i++) {
-                                        extensionValueList[i] = extensionJsonArray.get(i).getAsString();
-                                    }
-                                }
-
-                                finalExtensionMap.put(key, extensionValueList);
-                            }
-                    );
-
-            extensionMap = finalExtensionMap;
         }
 
-        CertStreamCertificatePOJO retVal =
-                jsonDeserializationContext.deserialize(jsonElement, type);
+        // parse entry normally
+        CertStreamCertificatePOJO retVal = new Gson().fromJson(jsonElement, CertStreamCertificatePOJO.class);
 
-        retVal.extensions = extensionMap;
+        // parse extensions externally
+        retVal.extensions = deserializeExtension(jsonExtensions);
 
         return retVal;
+    }
+
+    private HashMap<String, String[]> deserializeExtension(JsonObject extensions){
+        final HashMap<String, String[]> finalMap = new HashMap<>(extensions.size());
+
+        extensions.entrySet().forEach((Map.Entry<String, JsonElement> entry) -> {
+            String key = entry.getKey();
+            JsonElement value = entry.getValue();
+            String[] extensionValues;
+
+            try {
+                extensionValues = new String[] { value.getAsString() };
+            } catch (IllegalStateException | UnsupportedOperationException e) {
+                JsonArray extensionJsonArray = value.getAsJsonArray();
+                extensionValues = new String[extensionJsonArray.size()];
+
+                for (int i = 0; i < extensionJsonArray.size(); i++) {
+                    extensionValues[i] = extensionJsonArray.get(i).getAsString();
+                }
+            }
+
+            finalMap.put(key, extensionValues);
+        });
+
+        return finalMap;
     }
 }

--- a/src/io/calidog/certstream/CertStreamCertificatePOJODeserializer.java
+++ b/src/io/calidog/certstream/CertStreamCertificatePOJODeserializer.java
@@ -1,0 +1,62 @@
+package io.calidog.certstream;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+public class CertStreamCertificatePOJODeserializer implements JsonDeserializer<CertStreamCertificatePOJO> {
+
+    @Override
+    public CertStreamCertificatePOJO deserialize(
+            JsonElement jsonElement,
+            Type type,
+            JsonDeserializationContext jsonDeserializationContext
+    ) throws JsonParseException {
+        JsonObject jsonObj = jsonElement.getAsJsonObject();
+
+        JsonObject jsonExtensions;
+
+        HashMap<String, String[]> extensionMap = null;
+
+        if (jsonObj.has("extensions"))
+        {
+            jsonExtensions = jsonObj.remove("extensions").getAsJsonObject();
+
+            final HashMap<String, String[]> finalExtensionMap = new HashMap<>(jsonExtensions.size());
+
+            jsonExtensions
+                    .entrySet()
+                    .forEach
+                    (
+                            (java.util.Map.Entry<String, JsonElement> entry) ->
+                            {
+                                String key = entry.getKey();
+                                JsonElement value = entry.getValue();
+                                String[] extensionValueList;
+                                try {
+                                    extensionValueList = new String[] { value.getAsString() };
+                                } catch (IllegalStateException | UnsupportedOperationException e) {
+                                    JsonArray extensionJsonArray = value.getAsJsonArray();
+                                    extensionValueList = new String[extensionJsonArray.size()];
+
+                                    for (int i = 0; i < extensionJsonArray.size(); i++) {
+                                        extensionValueList[i] = extensionJsonArray.get(i).getAsString();
+                                    }
+                                }
+
+                                finalExtensionMap.put(key, extensionValueList);
+                            }
+                    );
+
+            extensionMap = finalExtensionMap;
+        }
+
+        CertStreamCertificatePOJO retVal =
+                jsonDeserializationContext.deserialize(jsonElement, type);
+
+        retVal.extensions = extensionMap;
+
+        return retVal;
+    }
+}


### PR DESCRIPTION
Hi,

I tried to fix the issue that the library isn't able to parse an entry that contains the field "extra" in the "extensions" section.

@joshbooks has tried to fix the bug before, so I used his solution as a starting point. Now the code doesn't create an infinite loop anymore and still parses the extensions correctly. 

Maybe you guys could look into it and see if it works for you.
Unfortunately I had to replace the NotImplementedException with an UnsupportedOperationException, because I work with OpenJDK and have no access to the reflectiveObjects packages.